### PR TITLE
Add support for datadog span types

### DIFF
--- a/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpan.scala
+++ b/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpan.scala
@@ -11,7 +11,7 @@ import io.circe.generic.semiauto._
 import io.janstenpickle.trace4cats.`export`.SemanticTags
 import io.janstenpickle.trace4cats.model.{AttributeValue, Batch}
 
-// implements https://docs.datadoghq.com/api/v1/tracing/
+// implements https://docs.datadoghq.com/api/v0.3/tracing/
 case class DataDogSpan(
   trace_id: BigInteger,
   span_id: BigInteger,
@@ -23,7 +23,8 @@ case class DataDogSpan(
   metrics: Map[String, Double],
   start: Long,
   duration: Long,
-  error: Option[Int]
+  error: Option[Int],
+  `type`: String
 )
 
 object DataDogSpan {
@@ -66,7 +67,8 @@ object DataDogSpan {
           allAttributes.get("error").map {
             case AttributeValue.BooleanValue(v) if v.value => 1
             case _ => 0
-          }
+          },
+          allAttributes.get("datadog.span_type").fold("custom")(_.toString),
         )
       })
 

--- a/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpan.scala
+++ b/modules/datadog-http-exporter/src/main/scala/io/janstenpickle/trace4cats/datadog/DataDogSpan.scala
@@ -11,7 +11,7 @@ import io.circe.generic.semiauto._
 import io.janstenpickle.trace4cats.`export`.SemanticTags
 import io.janstenpickle.trace4cats.model.{AttributeValue, Batch}
 
-// implements https://docs.datadoghq.com/api/v0.3/tracing/
+// implements https://docs.datadoghq.com/tracing/guide/send_traces_to_agent_by_api/
 case class DataDogSpan(
   trace_id: BigInteger,
   span_id: BigInteger,


### PR DESCRIPTION
This adds support for datadog's built in type.
See https://docs.datadoghq.com/tracing/guide/send_traces_to_agent_by_api/

These correspond to
![image](https://user-images.githubusercontent.com/1631523/154363437-bf9903ea-38dc-4f18-af4e-e2dd4c635cef.png)
