### PR TITLE
feat: support ns precision span duration reporting

### DIFF
--- a/modules/datadog-http-exporter/src/main/scala/trace4cats/datadog/DataDogSpan.scala
+++ b/modules/datadog-http-exporter/src/main/scala/trace4cats/datadog/DataDogSpan.scala
@@ -44,7 +44,8 @@ object DataDogSpan {
         val allAttributes = span.allAttributes ++ SemanticTags
           .kindTags(span.kind) ++ SemanticTags.statusTags("")(span.status)
 
-        val startNanos = TimeUnit.MILLISECONDS.toNanos(span.start.toEpochMilli)
+        val startNanos = TimeUnit.SECONDS.toNanos(span.start.getEpochSecond) + span.start.getNano
+        val endNanos = TimeUnit.SECONDS.toNanos(span.end.getEpochSecond) + span.end.getNano
 
         DataDogSpan(
           traceId,
@@ -63,7 +64,7 @@ object DataDogSpan {
             case (k, AttributeValue.LongValue(value)) => k -> value.value.toDouble
           },
           startNanos,
-          TimeUnit.MILLISECONDS.toNanos(span.end.toEpochMilli) - startNanos,
+          endNanos - startNanos,
           allAttributes.get("error").map {
             case AttributeValue.BooleanValue(v) if v.value => 1
             case _ => 0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala213 = "2.13.8"
     val scala3 = "3.3.0"
 
-    val trace4cats = "0.14.0"
+    val trace4cats = "0.14.5"
     val trace4catsExporterHttp = "0.14.0"
 
     val circe = "0.14.2"


### PR DESCRIPTION
Support finer-grained duration precision following the [0.14.3 release](https://github.com/trace4cats/trace4cats/releases/tag/v0.14.3) of trace4cats-core